### PR TITLE
Handled scenario where more than one BT adapter exists correctly

### DIFF
--- a/HandyApp/HandyApp/ViewModels/ListAdaptersViewModel.cs
+++ b/HandyApp/HandyApp/ViewModels/ListAdaptersViewModel.cs
@@ -143,16 +143,8 @@ namespace HandyApp.ViewModels
                        () =>
                        {
                            IsBusy = false;
-                           switch (Adapters.Count)
-                           {
-                               case 0:
-                                   Dialogs.Alert("No BluetoothLE Adapters Found");
-                                   break;
-
-                               case 1:
-                                   adapter = Adapters.First();
-                                   break;
-                           }
+                           if (Adapters.Count == 0) Dialogs.Alert("No BluetoothLE Adapters Found");
+                           else adapter = Adapters.First();
                        }
                    );
         }


### PR DESCRIPTION
Hi Cliff, I found your talk at NDC inspirational. I spotted a small bug in your code as you scrolled through so thought I'd fix it. You mentioned that some devices have more than one BT adapter, so you just pick the first, but your code doesn't behave in that way as you're switching on the length of the adapters array returned and only handling the case where there is one.